### PR TITLE
feat: add support for SameSite param in cookie

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13

--- a/manager.go
+++ b/manager.go
@@ -53,6 +53,9 @@ type Options struct {
 	// CookieLifeTime sets expiry time for cookie.
 	// If expiry time is not specified then cookie is set as session cookie which is cleared on browser close.
 	CookieLifetime time.Duration
+
+	// SameSite sets allows you to declare if your cookie should be restricted to a first-party or same-site context.
+	SameSite http.SameSite
 }
 
 // New creates a new session manager for given options.

--- a/manager_test.go
+++ b/manager_test.go
@@ -27,6 +27,7 @@ func TestManagerNewManagerWithOptions(t *testing.T) {
 		CookiePath:       "/abc/123",
 		IsSecureCookie:   true,
 		IsHTTPOnlyCookie: true,
+		SameSite:         http.SameSiteLaxMode,
 		CookieLifetime:   2000 * time.Millisecond,
 	}
 
@@ -40,6 +41,7 @@ func TestManagerNewManagerWithOptions(t *testing.T) {
 	assert.Equal(m.opts.CookieDomain, opts.CookieDomain)
 	assert.Equal(m.opts.CookiePath, opts.CookiePath)
 	assert.Equal(m.opts.IsSecureCookie, opts.IsSecureCookie)
+	assert.Equal(m.opts.SameSite, opts.SameSite)
 	assert.Equal(m.opts.IsHTTPOnlyCookie, opts.IsHTTPOnlyCookie)
 	assert.Equal(m.opts.CookieLifetime, opts.CookieLifetime)
 }

--- a/session.go
+++ b/session.go
@@ -140,6 +140,7 @@ func (s *Session) WriteCookie(cv string) error {
 		Path:     s.manager.opts.CookiePath,
 		Secure:   s.manager.opts.IsSecureCookie,
 		HttpOnly: s.manager.opts.IsHTTPOnlyCookie,
+		SameSite: s.manager.opts.SameSite,
 	}
 
 	// Set cookie expiry

--- a/session_test.go
+++ b/session_test.go
@@ -323,6 +323,7 @@ func TestSessionWriteCookie(t *testing.T) {
 		IsHTTPOnlyCookie: true,
 		IsSecureCookie:   true,
 		DisableAutoSet:   true,
+		SameSite:         http.SameSiteDefaultMode,
 	}
 	mockStore.isValid = true
 
@@ -335,6 +336,7 @@ func TestSessionWriteCookie(t *testing.T) {
 	assert.Equal(sess.cookie.Domain, mockManager.opts.CookieDomain)
 	assert.Equal(sess.cookie.Path, mockManager.opts.CookiePath)
 	assert.Equal(sess.cookie.Secure, mockManager.opts.IsSecureCookie)
+	assert.Equal(sess.cookie.SameSite, mockManager.opts.SameSite)
 	assert.Equal(sess.cookie.HttpOnly, mockManager.opts.IsHTTPOnlyCookie)
 
 	// Ignore seconds


### PR DESCRIPTION
Adds support SameSite cookie param - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Its optional and shouldn't break existing API.