### PR TITLE
Refactor all stores to remove the simplesessions dependency and adhere

### DIFF
--- a/stores/goredis/go.mod
+++ b/stores/goredis/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.32.1
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stretchr/testify v1.9.0
-	github.com/vividvilla/simplesessions v0.2.0
+	github.com/vividvilla/simplesessions/conv v1.0.0
 )
 
 require (

--- a/stores/goredis/store.go
+++ b/stores/goredis/store.go
@@ -2,13 +2,36 @@ package goredis
 
 import (
 	"context"
+	"crypto/rand"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/redis/go-redis/v9"
-	"github.com/vividvilla/simplesessions"
 	"github.com/vividvilla/simplesessions/conv"
 )
+
+var (
+	// Error codes for store errors. This should match the codes
+	// defined in the /simplesessions package exactly.
+	ErrInvalidSession = &Err{code: 1, msg: "invalid session"}
+	ErrFieldNotFound  = &Err{code: 2, msg: "field not found"}
+	ErrAssertType     = &Err{code: 3, msg: "assertion failed"}
+	ErrNil            = &Err{code: 4, msg: "nil returned"}
+)
+
+type Err struct {
+	code int
+	msg  string
+}
+
+func (e *Err) Error() string {
+	return e.msg
+}
+
+func (e *Err) Code() int {
+	return e.code
+}
 
 // Store represents redis session store for simple sessions.
 // Each session is stored as redis hashmap.
@@ -54,20 +77,9 @@ func (s *Store) SetTTL(d time.Duration) {
 	s.ttl = d
 }
 
-// isValidSessionID checks is the given session id is valid.
-func (s *Store) isValidSessionID(sess *simplesessions.Session, id string) bool {
-	return len(id) == sessionIDLen && sess.IsValidRandomString(id)
-}
-
-// IsValid checks if the session is set for the id.
-func (s *Store) IsValid(sess *simplesessions.Session, id string) (bool, error) {
-	// Validate session is valid generate string or not
-	return s.isValidSessionID(sess, id), nil
-}
-
 // Create returns a new session id but doesn't stores it in redis since empty hashmap can't be created.
-func (s *Store) Create(sess *simplesessions.Session) (string, error) {
-	id, err := sess.GenerateRandomString(sessionIDLen)
+func (s *Store) Create() (string, error) {
+	id, err := generateID(sessionIDLen)
 	if err != nil {
 		return "", err
 	}
@@ -76,25 +88,23 @@ func (s *Store) Create(sess *simplesessions.Session) (string, error) {
 }
 
 // Get gets a field in hashmap. If field is nill then ErrFieldNotFound is raised
-func (s *Store) Get(sess *simplesessions.Session, id, key string) (interface{}, error) {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return nil, simplesessions.ErrInvalidSession
+func (s *Store) Get(id, key string) (interface{}, error) {
+	if !validateID(id) {
+		return nil, ErrInvalidSession
 	}
 
 	v, err := s.client.HGet(s.clientCtx, s.prefix+id, key).Result()
 	if err == redis.Nil {
-		return nil, simplesessions.ErrFieldNotFound
+		return nil, ErrFieldNotFound
 	}
 
 	return v, err
 }
 
 // GetMulti gets a map for values for multiple keys. If key is not found then its set as nil.
-func (s *Store) GetMulti(sess *simplesessions.Session, id string, keys ...string) (map[string]interface{}, error) {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return nil, simplesessions.ErrInvalidSession
+func (s *Store) GetMulti(id string, keys ...string) (map[string]interface{}, error) {
+	if !validateID(id) {
+		return nil, ErrInvalidSession
 	}
 
 	v, err := s.client.HMGet(s.clientCtx, s.prefix+id, keys...).Result()
@@ -113,10 +123,9 @@ func (s *Store) GetMulti(sess *simplesessions.Session, id string, keys ...string
 }
 
 // GetAll gets all fields from hashmap.
-func (s *Store) GetAll(sess *simplesessions.Session, id string) (map[string]interface{}, error) {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return nil, simplesessions.ErrInvalidSession
+func (s *Store) GetAll(id string) (map[string]interface{}, error) {
+	if !validateID(id) {
+		return nil, ErrInvalidSession
 	}
 
 	res, err := s.client.HGetAll(s.clientCtx, s.prefix+id).Result()
@@ -136,10 +145,9 @@ func (s *Store) GetAll(sess *simplesessions.Session, id string) (map[string]inte
 }
 
 // Set sets a value to given session but stored only on commit
-func (s *Store) Set(sess *simplesessions.Session, id, key string, val interface{}) error {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return simplesessions.ErrInvalidSession
+func (s *Store) Set(id, key string, val interface{}) error {
+	if !validateID(id) {
+		return ErrInvalidSession
 	}
 
 	s.mu.Lock()
@@ -156,11 +164,10 @@ func (s *Store) Set(sess *simplesessions.Session, id, key string, val interface{
 	return nil
 }
 
-// Commit sets all set values
-func (s *Store) Commit(sess *simplesessions.Session, id string) error {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return simplesessions.ErrInvalidSession
+// Commit sets all set values.
+func (s *Store) Commit(id string) error {
+	if !validateID(id) {
+		return ErrInvalidSession
 	}
 
 	s.mu.RLock()
@@ -200,10 +207,9 @@ func (s *Store) Commit(sess *simplesessions.Session, id string) error {
 }
 
 // Delete deletes a key from redis session hashmap.
-func (s *Store) Delete(sess *simplesessions.Session, id string, key string) error {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return simplesessions.ErrInvalidSession
+func (s *Store) Delete(id string, key string) error {
+	if !validateID(id) {
+		return ErrInvalidSession
 	}
 
 	// Clear temp map for given session id
@@ -213,16 +219,15 @@ func (s *Store) Delete(sess *simplesessions.Session, id string, key string) erro
 
 	err := s.client.HDel(s.clientCtx, s.prefix+id, key).Err()
 	if err == redis.Nil {
-		return simplesessions.ErrFieldNotFound
+		return ErrFieldNotFound
 	}
 	return err
 }
 
 // Clear clears session in redis.
-func (s *Store) Clear(sess *simplesessions.Session, id string) error {
-	// Check if valid session
-	if !s.isValidSessionID(sess, id) {
-		return simplesessions.ErrInvalidSession
+func (s *Store) Clear(id string) error {
+	if !validateID(id) {
+		return ErrInvalidSession
 	}
 
 	return s.client.Del(s.clientCtx, s.prefix+id).Err()
@@ -261,4 +266,33 @@ func (s *Store) Bytes(r interface{}, err error) ([]byte, error) {
 // Bool returns redis reply as Bool.
 func (s *Store) Bool(r interface{}, err error) (bool, error) {
 	return conv.Bool(r, err)
+}
+
+func validateID(id string) bool {
+	if len(id) != sessionIDLen {
+		return false
+	}
+
+	for _, r := range id {
+		if !unicode.IsDigit(r) && !unicode.IsLetter(r) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// generateID generates a random alpha-num session ID.
+func generateID(n int) (string, error) {
+	const dict = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	bytes := make([]byte, n)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+
+	for k, v := range bytes {
+		bytes[k] = dict[v%byte(len(dict))]
+	}
+
+	return string(bytes), nil
 }

--- a/stores/memory/go.mod
+++ b/stores/memory/go.mod
@@ -1,11 +1,8 @@
-module github.com/vividvilla/simplesessions/stores/memory
+module github.com/vividvilla/simplesessions/stores/memory/v2
 
 go 1.18
 
-require (
-	github.com/stretchr/testify v1.9.0
-	github.com/vividvilla/simplesessions v0.2.0
-)
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/stores/memory/store_test.go
+++ b/stores/memory/store_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vividvilla/simplesessions"
 )
 
 func TestNew(t *testing.T) {
@@ -16,65 +15,59 @@ func TestNew(t *testing.T) {
 
 func TestIsValidSessionID(t *testing.T) {
 	assert := assert.New(t)
-	str := New()
-	sess := &simplesessions.Session{}
 
 	// Not valid since length doesn't match
 	testString := "abc123"
 	assert.NotEqual(len(testString), sessionIDLen)
-	assert.False(str.isValidSessionID(sess, testString))
+	assert.False(validateID(testString))
 
 	// Not valid since length is same but not alpha numeric
 	invalidTestString := "0dIHy6S2uBuKaNnTUszB218L898ikGY$"
 	assert.Equal(len(invalidTestString), sessionIDLen)
-	assert.False(str.isValidSessionID(sess, invalidTestString))
+	assert.False(validateID(invalidTestString))
 
 	// Valid
 	validTestString := "1dIHy6S2uBuKaNnTUszB218L898ikGY1"
 	assert.Equal(len(validTestString), sessionIDLen)
-	assert.True(str.isValidSessionID(sess, validTestString))
+	assert.True(validateID(validTestString))
 }
 
 func TestIsValid(t *testing.T) {
 	assert := assert.New(t)
-	str := New()
-	sess := &simplesessions.Session{}
 
 	// Not valid since length doesn't match
 	testString := "abc123"
 	assert.NotEqual(len(testString), sessionIDLen)
-	assert.False(str.IsValid(sess, testString))
+	assert.False(validateID(testString))
 
 	// Not valid since length is same but not alpha numeric
 	invalidTestString := "2dIHy6S2uBuKaNnTUszB218L898ikGY$"
 	assert.Equal(len(invalidTestString), sessionIDLen)
-	assert.False(str.IsValid(sess, invalidTestString))
+	assert.False(validateID(invalidTestString))
 
 	// Valid
 	validTestString := "3dIHy6S2uBuKaNnTUszB218L898ikGY1"
 	assert.Equal(len(validTestString), sessionIDLen)
-	assert.True(str.IsValid(sess, validTestString))
+	assert.True(validateID(validTestString))
 }
 
 func TestCreate(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	id, err := str.Create(sess)
+	id, err := str.Create()
 	assert.Nil(err)
 	assert.Equal(len(id), sessionIDLen)
-	assert.True(str.IsValid(sess, id))
+	assert.True(validateID(id))
 }
 
 func TestGetInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	val, err := str.Get(sess, "invalidkey", "invalidkey")
+	val, err := str.Get("invalidkey", "invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestGet(t *testing.T) {
@@ -85,11 +78,11 @@ func TestGet(t *testing.T) {
 
 	// Set a key
 	str := New()
-	sess := &simplesessions.Session{}
+
 	str.sessions[key] = make(map[string]interface{})
 	str.sessions[key][field] = value
 
-	val, err := str.Get(sess, key, field)
+	val, err := str.Get(key, field)
 	assert.NoError(err)
 	assert.Equal(val, value)
 }
@@ -97,31 +90,28 @@ func TestGet(t *testing.T) {
 func TestGetFieldNotFoundError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
 	key := "10IHy6S2uBuKaNnTUszB218L898ikGY1"
-	val, err := str.Get(sess, key, "invalidkey")
+	val, err := str.Get(key, "invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrFieldNotFound.Error())
+	assert.Error(err, ErrFieldNotFound.Error())
 }
 
 func TestGetMultiInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	val, err := str.GetMulti(sess, "invalidkey", "invalidkey")
+	val, err := str.GetMulti("invalidkey", "invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestGetMultiFieldEmptySession(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
 	key := "11IHy6S2uBuKaNnTUszB218L898ikGY1"
-	_, err := str.GetMulti(sess, key)
+	_, err := str.GetMulti(key)
 	assert.Nil(err)
 }
 
@@ -136,7 +126,6 @@ func TestGetMulti(t *testing.T) {
 	value3 := 100.10
 
 	str := New()
-	sess := &simplesessions.Session{}
 
 	// Set a key
 	str.sessions[key] = make(map[string]interface{})
@@ -144,7 +133,7 @@ func TestGetMulti(t *testing.T) {
 	str.sessions[key][field2] = value2
 	str.sessions[key][field3] = value3
 
-	vals, err := str.GetMulti(sess, key, field1, field2)
+	vals, err := str.GetMulti(key, field1, field2)
 	assert.NoError(err)
 	assert.Contains(vals, field1)
 	assert.Contains(vals, field2)
@@ -160,11 +149,10 @@ func TestGetMulti(t *testing.T) {
 func TestGetAllInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	val, err := str.GetAll(sess, "invalidkey")
+	val, err := str.GetAll("invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestGetAll(t *testing.T) {
@@ -178,7 +166,6 @@ func TestGetAll(t *testing.T) {
 	value3 := 100.10
 
 	str := New()
-	sess := &simplesessions.Session{}
 
 	// Set a key
 	str.sessions[key] = make(map[string]interface{})
@@ -186,7 +173,7 @@ func TestGetAll(t *testing.T) {
 	str.sessions[key][field2] = value2
 	str.sessions[key][field3] = value3
 
-	vals, err := str.GetAll(sess, key)
+	vals, err := str.GetAll(key)
 	assert.NoError(err)
 	assert.Contains(vals, field1)
 	assert.Contains(vals, field2)
@@ -205,17 +192,15 @@ func TestGetAll(t *testing.T) {
 func TestSetInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	err := str.Set(sess, "invalidid", "key", "value")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Set("invalidid", "key", "value")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestSet(t *testing.T) {
 	// Test should only set in internal map and not in redis
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
 	// this key is unique across all tests
 	key := "7dIHy6S2uBuKaNnTUszB218L898ikGY9"
@@ -224,7 +209,7 @@ func TestSet(t *testing.T) {
 
 	assert.NotContains(str.sessions, key)
 
-	err := str.Set(sess, key, field, value)
+	err := str.Set(key, field, value)
 	assert.NoError(err)
 	assert.Contains(str.sessions, key)
 	assert.Contains(str.sessions[key], field)
@@ -234,26 +219,23 @@ func TestSet(t *testing.T) {
 func TestCommit(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	err := str.Commit(sess, "invalidkey")
+	err := str.Commit("invalidkey")
 	assert.Nil(err)
 }
 
 func TestDeleteInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	err := str.Delete(sess, "invalidkey", "somekey")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Delete("invalidkey", "somekey")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestDelete(t *testing.T) {
 	// Test should only set in internal map and not in redis
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
 	// this key is unique across all tests
 	key := "8dIHy6S2uBuKaNnTUszB2180898ikGY1"
@@ -263,7 +245,7 @@ func TestDelete(t *testing.T) {
 	str.sessions[key][field1] = 10
 	str.sessions[key][field2] = 10
 
-	err := str.Delete(sess, key, field1)
+	err := str.Delete(key, field1)
 	assert.NoError(err)
 	assert.Contains(str.sessions[key], field2)
 	assert.NotContains(str.sessions[key], field1)
@@ -272,23 +254,21 @@ func TestDelete(t *testing.T) {
 func TestClearInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
-	err := str.Clear(sess, "invalidkey")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Clear("invalidkey")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestClear(t *testing.T) {
 	// Test should only set in internal map and not in redis
 	assert := assert.New(t)
 	str := New()
-	sess := &simplesessions.Session{}
 
 	// this key is unique across all tests
 	key := "8dIHy6S2uBuKaNnTUszB2180898ikGY1"
 	str.sessions[key] = make(map[string]interface{})
 
-	err := str.Clear(sess, key)
+	err := str.Clear(key)
 	assert.NoError(err)
 	assert.NotContains(str.sessions, key)
 }
@@ -308,7 +288,7 @@ func TestInt(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.Int("string", nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }
 
 func TestInt64(t *testing.T) {
@@ -325,7 +305,7 @@ func TestInt64(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.Int64("string", nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }
 
 func TestUInt64(t *testing.T) {
@@ -342,7 +322,7 @@ func TestUInt64(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.UInt64("string", nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }
 
 func TestFloat64(t *testing.T) {
@@ -359,7 +339,7 @@ func TestFloat64(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.Float64("string", nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }
 
 func TestString(t *testing.T) {
@@ -376,7 +356,7 @@ func TestString(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.String(123, nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }
 
 func TestBytes(t *testing.T) {
@@ -393,7 +373,7 @@ func TestBytes(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.Bytes("string", nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }
 
 func TestBool(t *testing.T) {
@@ -410,5 +390,5 @@ func TestBool(t *testing.T) {
 	assert.Error(testError)
 
 	_, err = str.Bool("string", nil)
-	assert.Error(simplesessions.ErrAssertType)
+	assert.Error(ErrAssertType)
 }

--- a/stores/redis/go.mod
+++ b/stores/redis/go.mod
@@ -1,4 +1,4 @@
-module github.com/vividvilla/simplesessions/stores/redis
+module github.com/vividvilla/simplesessions/stores/redis/v2
 
 go 1.18
 
@@ -6,7 +6,6 @@ require (
 	github.com/alicebob/miniredis/v2 v2.32.1
 	github.com/gomodule/redigo v1.9.2
 	github.com/stretchr/testify v1.9.0
-	github.com/vividvilla/simplesessions v0.2.0
 )
 
 require (

--- a/stores/redis/store_test.go
+++ b/stores/redis/store_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vividvilla/simplesessions"
-
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
@@ -62,67 +60,22 @@ func TestSetTTL(t *testing.T) {
 	assert.Equal(str.ttl, testDur)
 }
 
-func TestIsValidSessionID(t *testing.T) {
-	assert := assert.New(t)
-	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
-
-	// Not valid since length doesn't match
-	testString := "abc123"
-	assert.NotEqual(len(testString), sessionIDLen)
-	assert.False(str.isValidSessionID(sess, testString))
-
-	// Not valid since length is same but not alpha numeric
-	invalidTestString := "0dIHy6S2uBuKaNnTUszB218L898ikGY$"
-	assert.Equal(len(invalidTestString), sessionIDLen)
-	assert.False(str.isValidSessionID(sess, invalidTestString))
-
-	// Valid
-	validTestString := "1dIHy6S2uBuKaNnTUszB218L898ikGY1"
-	assert.Equal(len(validTestString), sessionIDLen)
-	assert.True(str.isValidSessionID(sess, validTestString))
-}
-
-func TestIsValid(t *testing.T) {
-	assert := assert.New(t)
-	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
-
-	// Not valid since length doesn't match
-	testString := "abc123"
-	assert.NotEqual(len(testString), sessionIDLen)
-	assert.False(str.IsValid(sess, testString))
-
-	// Not valid since length is same but not alpha numeric
-	invalidTestString := "2dIHy6S2uBuKaNnTUszB218L898ikGY$"
-	assert.Equal(len(invalidTestString), sessionIDLen)
-	assert.False(str.IsValid(sess, invalidTestString))
-
-	// Valid
-	validTestString := "3dIHy6S2uBuKaNnTUszB218L898ikGY1"
-	assert.Equal(len(validTestString), sessionIDLen)
-	assert.True(str.IsValid(sess, validTestString))
-}
-
 func TestCreate(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	id, err := str.Create(sess)
+	id, err := str.Create()
 	assert.Nil(err)
 	assert.Equal(len(id), sessionIDLen)
-	assert.True(str.IsValid(sess, id))
 }
 
 func TestGetInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	val, err := str.Get(sess, "invalidkey", "invalidkey")
+	val, err := str.Get("invalidkey", "invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestGet(t *testing.T) {
@@ -139,9 +92,8 @@ func TestGet(t *testing.T) {
 	assert.NoError(err)
 
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
-	val, err := redis.Int(str.Get(sess, key, field))
+	val, err := redis.Int(str.Get(key, field))
 	assert.NoError(err)
 	assert.Equal(val, value)
 }
@@ -149,32 +101,29 @@ func TestGet(t *testing.T) {
 func TestGetFieldNotFoundError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
 	key := "10IHy6S2uBuKaNnTUszB218L898ikGY1"
-	val, err := str.Get(sess, key, "invalidkey")
+	val, err := str.Get(key, "invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrFieldNotFound.Error())
+	assert.Error(err, ErrFieldNotFound.Error())
 }
 
 func TestGetMultiInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	val, err := str.GetMulti(sess, "invalidkey", "invalidkey")
+	val, err := str.GetMulti("invalidkey", "invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestGetMultiFieldEmptySession(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
 	key := "11IHy6S2uBuKaNnTUszB218L898ikGY1"
 	field := "somefield"
-	_, err := str.GetMulti(sess, key, field)
+	_, err := str.GetMulti(key, field)
 	assert.Nil(err)
 }
 
@@ -196,9 +145,8 @@ func TestGetMulti(t *testing.T) {
 	assert.NoError(err)
 
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
-	vals, err := str.GetMulti(sess, key, field1, field2)
+	vals, err := str.GetMulti(key, field1, field2)
 	assert.NoError(err)
 	assert.Contains(vals, field1)
 	assert.Contains(vals, field2)
@@ -216,11 +164,10 @@ func TestGetMulti(t *testing.T) {
 func TestGetAllInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	val, err := str.GetAll(sess, "invalidkey")
+	val, err := str.GetAll("invalidkey")
 	assert.Nil(val)
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestGetAll(t *testing.T) {
@@ -241,9 +188,8 @@ func TestGetAll(t *testing.T) {
 	assert.NoError(err)
 
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
-	vals, err := str.GetAll(sess, key)
+	vals, err := str.GetAll(key)
 	assert.NoError(err)
 	assert.Contains(vals, field1)
 	assert.Contains(vals, field2)
@@ -265,10 +211,9 @@ func TestGetAll(t *testing.T) {
 func TestSetInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	err := str.Set(sess, "invalidid", "key", "value")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Set("invalidid", "key", "value")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestSet(t *testing.T) {
@@ -276,7 +221,6 @@ func TestSet(t *testing.T) {
 	assert := assert.New(t)
 	redisPool := getRedisPool()
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
 	// this key is unique across all tests
 	key := "7dIHy6S2uBuKaNnTUszB218L898ikGY9"
@@ -286,7 +230,7 @@ func TestSet(t *testing.T) {
 	assert.NotNil(str.tempSetMap)
 	assert.NotContains(str.tempSetMap, key)
 
-	err := str.Set(sess, key, field, value)
+	err := str.Set(key, field, value)
 	assert.NoError(err)
 	assert.Contains(str.tempSetMap, key)
 	assert.Contains(str.tempSetMap[key], field)
@@ -304,18 +248,16 @@ func TestSet(t *testing.T) {
 func TestCommitInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	err := str.Commit(sess, "invalidkey")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Commit("invalidkey")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestEmptyCommit(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	err := str.Commit(sess, "15IHy6S2uBuKaNnTUszB2180898ikGY1")
+	err := str.Commit("15IHy6S2uBuKaNnTUszB2180898ikGY1")
 	assert.NoError(err)
 }
 
@@ -324,7 +266,6 @@ func TestCommit(t *testing.T) {
 	assert := assert.New(t)
 	redisPool := getRedisPool()
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
 	str.SetTTL(10 * time.Second)
 
@@ -335,13 +276,13 @@ func TestCommit(t *testing.T) {
 	field2 := "someotherkey"
 	value2 := "abc123"
 
-	err := str.Set(sess, key, field1, value1)
+	err := str.Set(key, field1, value1)
 	assert.NoError(err)
 
-	err = str.Set(sess, key, field2, value2)
+	err = str.Set(key, field2, value2)
 	assert.NoError(err)
 
-	err = str.Commit(sess, key)
+	err = str.Commit(key)
 	assert.NoError(err)
 
 	conn := redisPool.Get()
@@ -358,10 +299,9 @@ func TestCommit(t *testing.T) {
 func TestDeleteInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	err := str.Delete(sess, "invalidkey", "somefield")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Delete("invalidkey", "somefield")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestDelete(t *testing.T) {
@@ -369,7 +309,6 @@ func TestDelete(t *testing.T) {
 	assert := assert.New(t)
 	redisPool := getRedisPool()
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
 	// this key is unique across all tests
 	key := "8dIHy6S2uBuKaNnTUszB2180898ikGY1"
@@ -383,7 +322,7 @@ func TestDelete(t *testing.T) {
 	_, err := conn.Do("HMSET", defaultPrefix+key, field1, value1, field2, value2)
 	assert.NoError(err)
 
-	err = str.Delete(sess, key, field1)
+	err = str.Delete(key, field1)
 	assert.NoError(err)
 
 	val, err := redis.Bool(conn.Do("HEXISTS", defaultPrefix+key, field1))
@@ -396,10 +335,9 @@ func TestDelete(t *testing.T) {
 func TestClearInvalidSessionError(t *testing.T) {
 	assert := assert.New(t)
 	str := New(getRedisPool())
-	sess := &simplesessions.Session{}
 
-	err := str.Clear(sess, "invalidkey")
-	assert.Error(err, simplesessions.ErrInvalidSession.Error())
+	err := str.Clear("invalidkey")
+	assert.Error(err, ErrInvalidSession.Error())
 }
 
 func TestClear(t *testing.T) {
@@ -407,7 +345,6 @@ func TestClear(t *testing.T) {
 	assert := assert.New(t)
 	redisPool := getRedisPool()
 	str := New(redisPool)
-	sess := &simplesessions.Session{}
 
 	// this key is unique across all tests
 	key := "8dIHy6S2uBuKaNnTUszB2180898ikGY1"
@@ -427,7 +364,7 @@ func TestClear(t *testing.T) {
 	// -2 represents key doesn't exist
 	assert.NotEqual(val, int64(-2))
 
-	err = str.Clear(sess, key)
+	err = str.Clear(key)
 	assert.NoError(err)
 
 	val, err = conn.Do("TTL", defaultPrefix+key)

--- a/stores/securecookie/go.mod
+++ b/stores/securecookie/go.mod
@@ -1,9 +1,8 @@
-module github.com/vividvilla/simplesessions/stores/securecookie
+module github.com/vividvilla/simplesessions/stores/securecookie/v2
 
 go 1.14
 
 require (
 	github.com/gorilla/securecookie v1.1.2
 	github.com/stretchr/testify v1.9.0
-	github.com/vividvilla/simplesessions v0.2.0
 )


### PR DESCRIPTION
to the new `simplesessions/v2` interface methods. This is a breaking change.`

This commit also refactors securestore and changes its behaviour.

This store is peculiar because it does not actually have a persistent backend store and instead uses the session/cookie ID string (value) itself as the encoded store. The older version thus relied on Session{} to write the cookie to the frontend, which is not ideal.

This version removes the dependency and leaves the actual cookie writing to the implementer. This commit introduces a new `Flush()` method that returns the encoded values set using Set(), which the implementer can then write to a cookie externally (with a `Session.WriteCookie()`).